### PR TITLE
Potential fix for code scanning alert no. 67: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,6 +4,9 @@ on:
   release:
     types: [published]
 
+permissions:
+  contents: write
+
 jobs:
   build:
     runs-on: ${{ matrix.os }}


### PR DESCRIPTION
Potential fix for [https://github.com/regtemp8/flipflip/security/code-scanning/67](https://github.com/regtemp8/flipflip/security/code-scanning/67)

Add an explicit `permissions` block at the workflow root so all jobs inherit least-privilege defaults.  
For this workflow, the best minimal non-breaking configuration is:

- `contents: write` (needed to upload release assets to a release)
  
No other scopes are required by the shown steps. This preserves current behavior while removing implicit broad defaults.

Edit only `.github/workflows/release.yml`, inserting the permissions block after the trigger section (`on:` …) and before `jobs:`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
